### PR TITLE
Make $st->execute_array(\%attr,@bind_values) work ....

### DIFF
--- a/lib/DBD/Mock.pm
+++ b/lib/DBD/Mock.pm
@@ -694,6 +694,24 @@ Gets/sets the fields to use for this statement.
 
 Gets/set the bound parameters to use for this statement.
 
+=item B<all_bound_params>
+
+Gets/set the all_bound_params parameters to use for this statement.  Each array item is an arrayref of bound_params of execute statements on this statement.
+
+If, for instance you made this series of calls:
+
+  my $sth = $dbh->prepare("DELETE FROM foo where baz = ? and flib = ?");
+  $sth->bind_param(1,'1');
+  $sth->bind_param(2,'foo');
+  $sth->execute();
+  $sth->bind_param(1,'2');
+  $sth->bind_param(2,'bar');
+  $sth->execute();
+
+This would return:
+
+  [['1','foo'],['2','bar']]
+
 =item B<return_data>  (Statement attribute 'mock_records')
 
 Gets/sets the data to return when asked (that is, when someone calls 'fetch' on the statement handle).
@@ -709,6 +727,10 @@ Returns true if the statement is a SELECT and has more records to fetch, false o
 =item B<is_executed( $yes_or_no )> (Statement attribute 'mock_is_executed')
 
 Sets the state of the tracker 'executed' flag.
+
+=item B<times_executed()>
+
+Returns how many times this statement has been executed (0 by default)
 
 =item B<is_finished( $yes_or_no )> (Statement attribute 'mock_is_finished')
 
@@ -740,7 +762,7 @@ Pushes C<@params> onto the list of already-set bound parameters.
 
 =item B<mark_executed()>
 
-Tells the tracker that the statement has been executed and resets the current record number to '0'.
+Tells the tracker that the statement has been executed and resets the current record number to '0'.  Also saves the current bound params to 'all_bound_params' property.
 
 =item B<next_record()>
 

--- a/lib/DBD/Mock/st.pm
+++ b/lib/DBD/Mock/st.pm
@@ -41,6 +41,15 @@ sub bind_param_inout {
     return 1;
 }
 
+#NB: this essentially does not work with named parameters, because DBD::Mock support is very rudimentary
+#Details: 
+#DBD::Mock always assumes that $sth->bind_param(':foo','bar') is a new named parameter, so even in this sequence:
+#$sth->prepare('insert into my_table (column1) values(:foo)');
+#$sth->bind_param(':foo','bar')
+#$sth->execute();
+#$sth->bind_param(':foo','baz')
+#$sth->execute();
+#DBD::Mock will tell you that 'bar','baz' were two parameters passed to 1 execute
 sub execute_array {
     my ( $sth, $attr, @bind_values ) = @_;
 

--- a/lib/DBD/Mock/st.pm
+++ b/lib/DBD/Mock/st.pm
@@ -44,18 +44,37 @@ sub bind_param_inout {
 sub execute_array {
     my ( $sth, $attr, @bind_values ) = @_;
 
-    # no bind values means we're relying on prior calls to bind_param_array()
-    # for our data
+    if (@bind_values){
+        #i.e. if $sth->execute_array(\%attr,[1,2,3],[4,5,6]) is called, 
+        #that should translate to:
+        # $sth->bind_param_array(1,[1,2,3])
+        # $sth->bind_param_array(2,[4,5,6])
+        #etc
+        #TODO: pad shorter arrays out with nulls, as the docs for DBI suggest
+        for (my $i = 1;$i<=@bind_values;$i++){
+            if (! UNIVERSAL::isa( $bind_values[$i-1], 'ARRAY' ) ){
+                $sth->{Database}->set_err( 1, "execute_array expects the 3rd param onwards to be array references, not ". $bind_values[$i-1] );
+                return undef;
+            }
+            $sth->bind_param_array($i,$bind_values[$i-1]);
+        }
+    }
+
     my $tracker = $sth->FETCH('mock_my_history');
-    # don't use a reference; there's some magic attached to it somewhere
-    # so make it a lovely, simple array as soon as possible
     my @bound = @{ $tracker->bound_params() };
-    foreach my $p (@bound) {
-        my $result = $sth->execute( @$p );
-        # store the result from execute() if ArrayTupleStatus attribute is
-        # passed
-        push @{ $attr->{ArrayTupleStatus} }, $result
-            if (exists $attr->{ArrayTupleStatus});
+    if (@bound > 0 && scalar(@{$bound[0]}) > 0){
+        #flip through the arrays, grabbing each value in order
+        for (my $i=0;$i<scalar(@{$bound[0]});$i++){
+            my @p = ();
+            foreach my $param (@bound){
+                push(@p,$param->[$i]);
+            }
+            my $result = $sth->execute( @p );
+            # store the result from execute() if ArrayTupleStatus attribute is
+            # passed
+            push @{ $attr->{ArrayTupleStatus} }, $result
+                if (exists $attr->{ArrayTupleStatus});
+        }
     }
 
     # TODO: the docs say:

--- a/t/018_mock_statement_track.t
+++ b/t/018_mock_statement_track.t
@@ -1,6 +1,6 @@
 use strict;
 
-use Test::More tests => 68;
+use Test::More tests => 70;
 
 BEGIN {
     use_ok('DBD::Mock');
@@ -23,6 +23,7 @@ BEGIN {
     can_ok($st_track, 'is_depleted');
     can_ok($st_track, 'to_string');
     can_ok($st_track, 'is_executed');
+    can_ok($st_track, 'times_executed');
     can_ok($st_track, 'statement');
     can_ok($st_track, 'current_record_num');
     can_ok($st_track, 'return_data');
@@ -47,6 +48,7 @@ BEGIN {
     
     is($st_track->statement(), '', '... our statement is a blank string in the default');
     is($st_track->is_executed(), 'no', '... our statement is not executed in the default');
+    is($st_track->times_executed(), '0', '... our statement is executed 0 times in the default');
     
     ok($st_track->is_depleted(), '... the default state is depleted');
     ok(!defined($st_track->next_record()), '... the default state has no next record since it is depleted');

--- a/t/030_st_execute_array.t
+++ b/t/030_st_execute_array.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Exception; 
 
 # test style cribbed from t/013_st_execute_bound_params.t
 
@@ -30,5 +31,51 @@ my $sql = 'INSERT INTO staff (first_name, last_name, dept) VALUES(?, ?, ?)';
     ok( ! $@, 'Called execute_array() ok' )
         or diag $@;
 }
+
+subtest 'execute_array with multiple bind values' => sub {
+    my $dbh = DBI->connect( 'DBI:Mock:', '', '' );
+    my $qry = qq{ insert into mytable (foo,bar,baz) values (?,?,?) };                                                                                            
+    my $sqlh = $dbh->prepare($qry);                                                                                                                                                 
+    $sqlh->execute_array( { ArrayTupleStatus => \my @tuple_status },                                                                                                         
+        [1,2,3],
+        [4,5,6],
+        [7,8,9]
+    );
+    $sqlh->finish();                                                                                                                                                             
+
+    #interrogate the statement tracker
+    my $history = $dbh->{mock_all_history}->[0];                                                                                                                                     
+    is($history->{bound_params}->[0],3,'execute_array(\%attrs,bind_values) should bind parameters column-wise when provided, 1st column first');
+    is($history->{bound_params}->[1],6,'execute_array(\%attrs,bind_values) should bind parameters column-wise when provided, 2st column second');
+    is($history->{bound_params}->[2],9,'execute_array(\%attrs,bind_values) should bind parameters column-wise when provided, 3st column third');
+};
+
+subtest 'execute_array with single bind values' => sub {
+    my $dbh = DBI->connect( 'DBI:Mock:', '', '' );
+    my $qry = qq{ insert into mytable (foo,bar,baz) values (?,?,?) };                                                                                            
+    my $sqlh = $dbh->prepare($qry);                                                                                                                                                 
+    $sqlh->execute_array( { ArrayTupleStatus => \my @tuple_status },                                                                                                         
+        [1],
+        [2],
+        [3]
+    );
+    $sqlh->finish();                                                                                                                                                             
+
+    #interrogate the statement tracker
+    my $history = $dbh->{mock_all_history}->[0];                                                                                                                                     
+    is($history->{bound_params}->[0],1,'execute_array(\%attrs,bind_values) should bind parameters column-wise when provided, 1st column first');
+    is($history->{bound_params}->[1],2,'execute_array(\%attrs,bind_values) should bind parameters column-wise when provided, 2st column second');
+    is($history->{bound_params}->[2],3,'execute_array(\%attrs,bind_values) should bind parameters column-wise when provided, 3st column third');
+};
+
+subtest 'execute_array should complain if not provided array refs after \%attrs' => sub {
+    my $dbh = DBI->connect( 'DBI:Mock:', '', '' );
+    $dbh->{RaiseError} = 1;
+    $dbh->{PrintError} = 0;
+    my $qry = qq{ insert into mytable (foo,bar,baz) values (?,?,?) };                                                                                            
+    my $sqlh = $dbh->prepare($qry);                                                                                                                                                 
+    throws_ok { $sqlh->execute_array( { ArrayTupleStatus => \my @tuple_status },1,2,3); } qr/execute_array expects the 3rd param onwards to be array references/,
+        'Should complain if you do pass non-array refs for the 3rd parameter' ;
+};
 
 done_testing;

--- a/t/031_all_bound_params.t
+++ b/t/031_all_bound_params.t
@@ -1,0 +1,54 @@
+use 5.006;
+
+use strict;
+use warnings;
+use Test::Exception;
+use Test::More tests => 12;
+use Data::Dumper;
+
+BEGIN {
+    use_ok('DBD::Mock');
+    use_ok('DBI');
+}
+
+my $dbh = DBI->connect( 'DBI:Mock:', '', '', { RaiseError => 1 } );
+
+
+lives_ok(
+    sub {
+        $dbh->{mock_add_resultset} = [];
+        my $sth = $dbh->prepare("INSERT INTO foo (bar) VALUES (?)");
+
+        $sth->bind_param(1,'1');
+        $sth->execute();
+
+        {
+            my $st_track = $dbh->{mock_all_history}->[0];
+            is($st_track->times_executed(),1,'... Should know it was executed once');
+            is($st_track->{all_bound_params}->[0]->[0],'1','... should have the bound parameter tracked correctly in all_bound_params');
+            is($st_track->{bound_params}->[0],'1','... should have the bound parameter tracked correctly in bound_params');
+        }
+
+        $sth->bind_param(1,'2');
+        $sth->execute();
+
+        {
+            my $st_track = $dbh->{mock_all_history}->[0];
+            is($st_track->times_executed(),2,'... Should know it was executed twice');
+            is($st_track->{all_bound_params}->[1]->[0],'2','... should have the bound parameter tracked correctly in all_bound_params');
+            is($st_track->{bound_params}->[0],'2','... should have the bound parameter tracked correctly in bound_params');
+        }
+
+        $sth->bind_param(1,'3');
+        $sth->execute();
+
+        {
+            my $st_track = $dbh->{mock_all_history}->[0];
+            is($st_track->times_executed(),3,'... Should know it was executed thrice');
+            is($st_track->{all_bound_params}->[2]->[0],'3','... should have the bound parameter tracked correctly in all_bound_params');
+            is($st_track->{bound_params}->[0],'3','... should have the bound parameter tracked correctly in bound_params');
+        }
+    },
+    'Successfully execute prepared insert statement multiple times'
+);
+


### PR DESCRIPTION
Well, closer to how DBI actually works, in that column-wise parameters are used sequentially.

I added another commit here that also separately tracks what parameters were bound for each execute done (either via execute_array or via multiple calls to execute).
