### PR TITLE
Add option for regex matching result sets

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -9,8 +9,9 @@ my $build = Module::Build->new(
     module_name => 'DBD::Mock',
     license     => 'perl',
     requires    => {
-        'perl' => '5.6.0',
-        'DBI'  => 1.30,
+        'perl'       => '5.6.0',
+        'DBI'        => 1.30,
+        'List::Util' => 1.27
     },
     optional       => {},
     build_requires => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,8 @@ WriteMakefile(
     'PREREQ_PM'    => {
         'DBI'             => '1.3',
         'Test::More'      => '0.47',
-        'Test::Exception' => '0.31'
+        'Test::Exception' => '0.31',
+        'List::Util'      => '1.27',
     },
     'INSTALLDIRS' => 'site',
     'EXE_FILES'   => [],

--- a/lib/DBD/Mock/db.pm
+++ b/lib/DBD/Mock/db.pm
@@ -3,6 +3,8 @@ package DBD::Mock::db;
 use strict;
 use warnings;
 
+use List::Util qw( first );
+
 our $imp_data_size = 0;
 
 sub ping {
@@ -84,7 +86,7 @@ sub prepare {
 
         my $rs;
         if ( my $all_rs = $dbh->{mock_rs} ) {
-            if ( my $by_name = $all_rs->{named}{$statement} ) {
+            if ( my $by_name = $all_rs->{named}{$statement} // first { $statement =~ m/$_->{regexp}/ } @{ $all_rs->{matching} } ) {
 
                 # We want to copy this, because it is meant to be reusable
                 $rs = [ @{ $by_name->{results} } ];
@@ -311,8 +313,9 @@ sub STORE {
     }
     elsif ( $attrib eq 'mock_add_resultset' ) {
         $dbh->{mock_rs} ||= {
-            named   => {},
-            ordered => []
+            named    => {},
+            ordered  => [],
+            matching => [],
         };
         if ( ref $value eq 'ARRAY' ) {
             my @copied_values = @{$value};
@@ -326,7 +329,16 @@ sub STORE {
                   "as hashref key to 'mock_add_resultset'.\n";
             }
             my @copied_values = @{ $value->{results} };
-            $dbh->{mock_rs}{named}{$name} = { results => \@copied_values, };
+
+            if ( ref $name eq "Regexp" ) {
+                push @{ $dbh->{mock_rs}{matching} }, {
+                    regexp => $name,
+                    results => \@copied_values,
+                };
+            } else {
+                $dbh->{mock_rs}{named}{$name} = { results => \@copied_values, };
+            }
+
             if ( exists $value->{failure} ) {
                 $dbh->{mock_rs}{named}{$name}{failure} =
                   [ @{ $value->{failure} }, ];

--- a/t/016_mock_add_resultset_test.t
+++ b/t/016_mock_add_resultset_test.t
@@ -1,6 +1,6 @@
 use strict;
 
-use Test::More tests => 22;
+use Test::More tests => 25;
 
 BEGIN {
     use_ok('DBD::Mock');  
@@ -101,6 +101,21 @@ $dbh->{mock_add_resultset} = {
     my ($result) = $sth->fetchrow_array();
 
     is($result, 200, '... got the result we expected');
+    
+    $sth->finish();
+}
+
+# check that statically assigned queries take precedence over regex matched ones
+{
+    my $sth = $dbh->prepare('SELECT foo FROM bar');
+    isa_ok($sth, 'DBI::st');
+
+    my $rows = $sth->execute();
+    is($rows, '0E0', '... got back 0E0 for rows with a SELECT statement');
+
+    my ($result) = $sth->fetchrow_array();
+
+    is($result, 50, '... got the result we expected');
     
     $sth->finish();
 }

--- a/t/016_mock_add_resultset_test.t
+++ b/t/016_mock_add_resultset_test.t
@@ -91,6 +91,12 @@ $dbh->{mock_add_resultset} = {
     results => [ [ 'foo' ], [ 200 ] ],
 };
 
+## This one should never be used as the above one will have precedence
+$dbh->{mock_add_resultset} = {
+    sql => qr/^SELECT foo FROM/,
+    results => [ [ 'foo' ], [ 300 ] ],
+};
+
 { 
     my $sth = $dbh->prepare('SELECT foo FROM oof');
     isa_ok($sth, 'DBI::st');

--- a/t/016_mock_add_resultset_test.t
+++ b/t/016_mock_add_resultset_test.t
@@ -1,6 +1,6 @@
 use strict;
 
-use Test::More tests => 19;
+use Test::More tests => 22;
 
 BEGIN {
     use_ok('DBD::Mock');  
@@ -81,6 +81,26 @@ $dbh->{mock_add_resultset} = {
     my ($result) = $sth->fetchrow_array();
 
     is($result, 50, '... got the result we expected');
+    
+    $sth->finish();
+}
+
+## test regular expression for query matching
+$dbh->{mock_add_resultset} = {
+    sql => qr/^SELECT foo/,
+    results => [ [ 'foo' ], [ 200 ] ],
+};
+
+{ 
+    my $sth = $dbh->prepare('SELECT foo FROM oof');
+    isa_ok($sth, 'DBI::st');
+
+    my $rows = $sth->execute();
+    is($rows, '0E0', '... got back 0E0 for rows with a SELECT statement');
+
+    my ($result) = $sth->fetchrow_array();
+
+    is($result, 200, '... got the result we expected');
     
     $sth->finish();
 }


### PR DESCRIPTION
I've extended `mock_add_resultset` to accept a reference to a regular expression as well as a static string.

Static string results sets will take precedence over the regex. If no static string result sets match then the first matching regex result set will take precedence (evaluated in the order their defined).